### PR TITLE
Fix version to support absolute paths

### DIFF
--- a/core/workspace.go
+++ b/core/workspace.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/chrisdail/pile/gitver"
 )
@@ -42,7 +43,7 @@ func (ws *workspace) ProjectPaths(projects []string) []string {
 
 	paths := make([]string, len(projects))
 	for i, project := range projects {
-		paths[i] = filepath.Join(ws.Dir, project)
+		paths[i] = filepath.Join(ws.Dir, strings.ReplaceAll(project, ws.Dir, ""))
 	}
 	return paths
 }


### PR DESCRIPTION
Before this change, `pile version` would return `0.untracked` for the
version when the paths it was supplied were all absolute, or ignore
arguments that were absolute paths:

Before:

```
❯ go run main.go version core
16.3ef37bc

❯ go run main.go version /Users/vroy/pile/core
0.untracked

❯ go run main.go version core /Users/vroy/pile/cmd
16.3ef37bc
```

With this fix:

```
❯ go run main.go version core
17.16f410d

❯ go run main.go version /Users/vroy/pile/core
17.16f410d

❯ go run main.go version core /Users/vroy/pile/cmd
26.16f410d
```