### PR TITLE
Print the image digest, not the pointer

### DIFF
--- a/registry/ecr.go
+++ b/registry/ecr.go
@@ -49,7 +49,7 @@ func (registry *AmazonECR) Contains(repository string, tag string) bool {
 			repository,
 			tag,
 			detail.ImagePushedAt,
-			detail.ImageDigest,
+			*detail.ImageDigest,
 		)
 		return true
 	}


### PR DESCRIPTION
From:

```
2020/06/30 11:27:40 Image in registry internal/terraform:5.eef40dd34 found, pushedAt 2020-02-10 19:49:48 +0000 UTC, digest: %!s(*string=0xc00042c120)
```

To:

```
2020/06/30 11:39:21 Image in registry internal/terraform:5.eef40dd34 found, pushedAt 2020-02-10 19:49:48 +0000 UTC, digest: sha256:6b3df7f54d218bdb2d8c3a58cdb0f100a73e4783e6fcf60643d9200e1244b15b
```